### PR TITLE
Look for libcrypto bundled with Windows python releases; provide option to use something else

### DIFF
--- a/ctypescrypto/__init__.py
+++ b/ctypescrypto/__init__.py
@@ -6,6 +6,7 @@
 
 from ctypes import CDLL, c_char_p, c_void_p, c_long,c_uint64
 from ctypes.util import find_library
+import os
 import sys
 global strings_loaded
 
@@ -18,15 +19,24 @@ def config(filename=None):
 
 __all__ = ['config']
 
-if sys.platform.startswith('win'):
-    __libname__ = find_library('libeay32')
-else:
-    __libname__ = find_library('crypto')
+__libname__ = os.environ.get("CTYPESCRYPTO_LIBCRYPTO")
+if __libname__ is None:
+    if sys.platform.startswith('win'):
+        __libname__ = find_library('libeay32')
+        if __libname__ is None:
+            # Look harder for the version bundled with Python
+            python_install_dir = os.path.dirname(sys.executable)
+            dlls_dir = os.path.join(python_install_dir, "DLLs")
+            if os.path.isdir(dlls_dir):
+                for f in os.listdir(dlls_dir):
+                    if f.startswith("libcrypto") and f.endswith(".dll"):
+                        __libname__ = os.path.join(dlls_dir, f)
+                        break
+    else:
+        __libname__ = find_library('crypto')
 
 if __libname__ is None:
     raise OSError("Cannot find OpenSSL crypto library")
-
-#__libname__ = "/usr/local/ssl/lib/libcrypto.so.1.1"
 
 libcrypto = CDLL(__libname__)
 libcrypto.OPENSSL_config.argtypes = (c_char_p, )


### PR DESCRIPTION
This is adding:
- a new code path for finding the libcrypto DLL that exists in Windows installations, if the previous search fails
- a way to USE another library altogether, which helps in case the lib isn't named "crypto" / isn't in PATH

New code path tested with python 3.10b3 on Windows.